### PR TITLE
add Github action to push to dockerhub

### DIFF
--- a/.github/workflows/deploy-image.yml
+++ b/.github/workflows/deploy-image.yml
@@ -1,0 +1,32 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs: 
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        push: true
+        tags: amirpourmand/simorq:latest

--- a/scripts/dockerhub_run.sh
+++ b/scripts/dockerhub_run.sh
@@ -1,0 +1,3 @@
+docker run --rm -v "$PWD:/srv/jekyll/" -p "8080:8080" \
+                    -it amirpourmand/simorq bundler  \
+                    exec jekyll serve --watch --port=8080 --host=0.0.0.0 


### PR DESCRIPTION
I added a GitHub action to push the image to dockerhub repo. This way, the size of the image is reduced to `300MB` instead of roughly `1GB`. It pushes the image to [here](https://hub.docker.com/r/amirpourmand/simorq). 

After that you can easily install the website locally using:

```
docker pull amirpourmand/simorq
```
and then
```
scripts/dockerhub_run.sh
```

Also, this is more stable.


However, to add this to your project you have to add your `DockerHub` account secrets using [this](https://medium.com/platformer-blog/lets-publish-a-docker-image-to-docker-hub-using-a-github-action-f0b17e5cceb3) tutorial. The secret in my script is `DOCKER_USERNAME` not `DOCKER_USER`. After that, you can use your own `Dockerhub repo` or I can add you to my repo as collaborator so that built image is pushed to dockerhub after each commit. 